### PR TITLE
feat: vertical and horizontal handlers

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,239 +1,237 @@
 export type ResizeOptions = {
-  disabled?: boolean
-  minimumSize?: number
-  maximumSize?: number | null
-  handlerSize?: number
-  handlers?: Handlers
-  borderStyle?: string
-}
+	disabled?: boolean;
+	minimumSize?: number;
+	maximumSize?: number | null;
+	handlerSize?: number;
+	handlers?: Handlers;
+	borderStyle?: string;
+};
 
 export type Handlers = {
-  leftTop?: boolean
-  leftBottom?: boolean
-  rightTop?: boolean
-  rightBottom?: boolean
-}
+	bottom?: boolean;
+	left?: boolean;
+	leftTop?: boolean;
+	leftBottom?: boolean;
+	right?: boolean;
+	rightTop?: boolean;
+	rightBottom?: boolean;
+	top?: boolean;
+};
 
 export const resize = (node: HTMLElement, options: ResizeOptions = {}) => {
-  let initialHeight: number
-  let initialWidth: number
+	let initialHeight: number;
+	let initialWidth: number;
 
-  let initialPosX: number
-  let initialPosY: number
+	let initialPosX: number;
+	let initialPosY: number;
 
-  let initialMouseX: number
-  let initialMouseY: number
+	let initialMouseX: number;
+	let initialMouseY: number;
 
-  let handledElement: HTMLElement | null
-  let transformMatrix: { x: number; y: number; z: number }
-  const handlersAvail: Handlers = {
-    leftTop: true,
-    leftBottom: true,
-    rightTop: true,
-    rightBottom: true
-  }
+	let handledElement: HTMLElement | null;
+	let transformMatrix: { x: number; y: number; z: number };
+	const handlersAvail: Handlers = {
+		leftTop: true,
+		leftBottom: true,
+		rightTop: true,
+		rightBottom: true
+	};
 
-  let {
-    minimumSize = options.minimumSize ?? 20,
-    disabled = options.disabled ?? false,
-    handlerSize = options.handlerSize ?? 10,
-    handlers = options.handlers ?? handlersAvail,
-    maximumSize = options.maximumSize ?? null,
-    borderStyle = options.borderStyle ?? '2px solid rgba(0, 0, 0, 0.4)',
-  } = options
+	let {
+		minimumSize = options.minimumSize ?? 20,
+		disabled = options.disabled ?? false,
+		handlerSize = options.handlerSize ?? 10,
+		handlers = options.handlers ?? handlersAvail,
+		maximumSize = options.maximumSize ?? null,
+		borderStyle = options.borderStyle ?? '2px solid rgba(0, 0, 0, 0.4)'
+	} = options;
 
-  const position = getComputedStyle(node).position
-  console.log(position)
-  node.style.position = position === "static" ? "absolute" : position
+	const position = getComputedStyle(node).position;
+	console.log(position);
+	node.style.position = position === 'static' ? 'absolute' : position;
 
-  const onResizeStart = (e: MouseEvent) => {
-    if (disabled) {
-      return
-    }
+	const onResizeStart = (e: MouseEvent) => {
+		if (disabled) {
+			return;
+		}
 
-    initialHeight = node.clientHeight
-    initialWidth = node.clientWidth
+		initialHeight = node.clientHeight;
+		initialWidth = node.clientWidth;
 
-    initialMouseX = e.pageX
-    initialMouseY = e.pageY
+		initialMouseX = e.pageX;
+		initialMouseY = e.pageY;
 
-    initialPosX = node.getBoundingClientRect().left
-    initialPosY = node.getBoundingClientRect().top
-    transformMatrix = getTransform(node)
+		initialPosX = node.getBoundingClientRect().left;
+		initialPosY = node.getBoundingClientRect().top;
+		transformMatrix = getTransform(node);
 
-    console.log(transformMatrix)
-    handledElement = e.target as HTMLElement
-    window.addEventListener('pointermove', onResize)
-    window.addEventListener('pointerup', onResizeStop)
-  }
+		console.log(transformMatrix);
+		handledElement = e.target as HTMLElement;
+		window.addEventListener('pointermove', onResize);
+		window.addEventListener('pointerup', onResizeStop);
+	};
 
-  const onResizeStop = () => {
-    window.removeEventListener('pointermove', onResize)
+	const onResizeStop = () => {
+		window.removeEventListener('pointermove', onResize);
 
-    handledElement = null
-    transformMatrix = {
-      x: 0,
-      y: 0,
-      z: 0
-    }
-  }
+		handledElement = null;
+		transformMatrix = {
+			x: 0,
+			y: 0,
+			z: 0
+		};
+	};
 
-  const onResize = (e: MouseEvent) => {
-    if (disabled) {
-      return
-    }
+	const onResize = (e: MouseEvent) => {
+		if (disabled) {
+			return;
+		}
 
-    const coordinates: string =
-      handledElement?.getAttribute('data-coordinates') ?? ''
-    if (coordinates.includes('right')) {
-      const width = initialWidth + (e.pageX - initialMouseX)
-      if (width > minimumSize && (maximumSize ? width < maximumSize : true)) {
-        node.style.width = `${width}px`
-      }
-    }
+		const coordinates: string = handledElement?.getAttribute('data-coordinates') ?? '';
+		if (coordinates.includes('right')) {
+			const width = initialWidth + (e.pageX - initialMouseX);
+			if (width > minimumSize && (maximumSize ? width < maximumSize : true)) {
+				node.style.width = `${width}px`;
+			}
+		}
 
-    if (coordinates.includes('bottom')) {
-      const height = initialHeight + (e.pageY - initialMouseY)
-      if (height > minimumSize && (maximumSize ? height < maximumSize : true)) {
-        node.style.height = `${height}px`
-      }
-    }
+		if (coordinates.includes('bottom')) {
+			const height = initialHeight + (e.pageY - initialMouseY);
+			if (height > minimumSize && (maximumSize ? height < maximumSize : true)) {
+				node.style.height = `${height}px`;
+			}
+		}
 
-    let matrixLeft: null | number = null
-    if (coordinates.includes('left')) {
-      const width = initialWidth - (e.pageX - initialMouseX)
+		let matrixLeft: null | number = null;
+		if (coordinates.includes('left')) {
+			const width = initialWidth - (e.pageX - initialMouseX);
 
-      const delta = e.pageX - initialMouseX
-      matrixLeft = delta + transformMatrix.x
+			const delta = e.pageX - initialMouseX;
+			matrixLeft = delta + transformMatrix.x;
 
+			if (width > minimumSize && (maximumSize ? width < maximumSize : true)) {
+				node.style.width = `${width}px`;
 
-      if (width > minimumSize && (maximumSize ? width < maximumSize : true)) {
-        node.style.width = `${width}px`
+				console.log(`translate3d(${matrixLeft}px, ${transformMatrix.y}px, ${transformMatrix.z}px)`);
+				node.style.transform = `translate3d(${matrixLeft}px, ${transformMatrix.y}px, ${transformMatrix.z}px)`;
+			}
+		}
 
+		if (coordinates.includes('top')) {
+			const height = initialHeight - (e.pageY - initialMouseY);
 
-        console.log(`translate3d(${matrixLeft}px, ${transformMatrix.y}px, ${transformMatrix.z}px)`)
-        node.style.transform = `translate3d(${matrixLeft}px, ${transformMatrix.y}px, ${transformMatrix.z}px)`
-      }
-    }
+			const delta = e.pageY - initialMouseY;
+			const matrixTop = delta + transformMatrix.y;
+			const matrixLeftTop = matrixLeft ? matrixLeft : transformMatrix.x;
 
-    if (coordinates.includes('top')) {
-      const height = initialHeight - (e.pageY - initialMouseY)
+			if (height > minimumSize && (maximumSize ? height < maximumSize : true)) {
+				node.style.height = `${height}px`;
 
-      const delta = e.pageY - initialMouseY
-      const matrixTop = delta + transformMatrix.y
-      const matrixLeftTop = matrixLeft ? matrixLeft : transformMatrix.x
+				node.style.transform = `translate3d(${matrixLeftTop}px, ${matrixTop}px, ${transformMatrix.z}px)`;
+			}
+		}
+	};
 
+	let resizers: HTMLElement[] = [];
+	Object.keys(handlers).forEach((key) => {
+		if (handlers[key as keyof Handlers] !== true) {
+			return;
+		}
 
-      if (height > minimumSize && (maximumSize ? height < maximumSize : true)) {
-        node.style.height = `${height}px`
+		const div = createResizersDiv(key.toLowerCase(), handlerSize, borderStyle);
+		node.appendChild(div);
+		div.addEventListener('pointerdown', onResizeStart);
+		resizers = [...resizers, div];
+	});
 
-        node.style.transform = `translate3d(${matrixLeftTop}px, ${matrixTop}px, ${transformMatrix.z}px)`
-      }
-    }
-  }
+	return {
+		destroy() {
+			window.removeEventListener('pointermove', onResize);
+			window.removeEventListener('pointerup', onResizeStop);
 
-  let resizers: HTMLElement[] = []
-  Object.keys(handlers).forEach((key) => {
-    if (handlers[key as keyof Handlers] !== true) {
-      return
-    }
+			resizers.forEach((div) => {
+				node.removeChild(div);
+			});
+		},
 
-    const div = createResizersDiv(key.toLowerCase(), handlerSize, borderStyle)
-    node.appendChild(div)
-    div.addEventListener('pointerdown', onResizeStart)
-    resizers = [...resizers, div]
-  })
+		update(options: ResizeOptions) {
+			disabled = options.disabled ?? false;
+			minimumSize = options.minimumSize ?? 20;
+			maximumSize = options.maximumSize ?? null;
+			handlers = options.handlers ?? handlersAvail;
+			borderStyle = options.borderStyle ?? '2px solid rgba(0, 0, 0, 0.4)';
+		}
+	};
+};
 
-  return {
-    destroy() {
-      window.removeEventListener('pointermove', onResize)
-      window.removeEventListener('pointerup', onResizeStop)
+const createResizersDiv = (coordinates: string, handlerSize: number, borderStyle: string) => {
+	const div = document.createElement('div');
+	let cursorDirection = '';
+	div.style.height = `${handlerSize}px`;
+	div.style.width = `${handlerSize}px`;
+	div.style.position = 'absolute';
+	div.classList.add('resizeable');
+	div.dataset.coordinates = coordinates;
 
-      resizers.forEach((div) => {
-        node.removeChild(div)
-      })
-    },
+	const positionStyle = `-${handlerSize / 2}px`;
+	if (coordinates.includes('top')) {
+		div.style['top'] = positionStyle;
+		div.style.borderTop = borderStyle;
+		cursorDirection += 'n';
+	}
 
-    update(options: ResizeOptions) {
-      disabled = options.disabled ?? false
-      minimumSize = options.minimumSize ?? 20
-      maximumSize = options.maximumSize ?? null
-      handlers = options.handlers ?? handlersAvail
-      borderStyle = options.borderStyle ?? '2px solid rgba(0, 0, 0, 0.4)'
-    }
-  }
-}
+	if (coordinates.includes('bottom')) {
+		div.style['bottom'] = positionStyle;
+		div.style.borderBottom = borderStyle;
+		cursorDirection += 's';
+	}
 
-const createResizersDiv = (
-  coordinates: string,
-  handlerSize: number,
-  borderStyle: string
-) => {
-  const div = document.createElement('div')
-  let cursorDirection = ''
-  div.style.height = `${handlerSize}px`
-  div.style.width = `${handlerSize}px`
-  div.style.position = 'absolute'
-  div.classList.add('resizeable')
-  div.dataset.coordinates = coordinates
+	if (coordinates.includes('right')) {
+		div.style['right'] = positionStyle;
+		div.style.borderRight = borderStyle;
+		cursorDirection += 'e';
+	}
 
-  const positionStyle = `-${handlerSize / 2}px`
-  if (coordinates.includes('top')) {
-    div.style['top'] = positionStyle
-    div.style.borderTop = borderStyle
-    cursorDirection += 'n'
-  }
+	if (coordinates.includes('left')) {
+		div.style['left'] = positionStyle;
+		div.style.borderLeft = borderStyle;
+		cursorDirection += 'w';
+	}
 
-  if (coordinates.includes('bottom')) {
-    div.style['bottom'] = positionStyle
-    div.style.borderBottom = borderStyle
-    cursorDirection += 's'
-  }
+	div.style.cursor = `${cursorDirection}-resize`;
 
-  if (coordinates.includes('right')) {
-    div.style['right'] = positionStyle
-    div.style.borderRight = borderStyle
-    cursorDirection += 'e'
-  }
-
-  if (coordinates.includes('left')) {
-    div.style['left'] = positionStyle
-    div.style.borderLeft = borderStyle
-    cursorDirection += 'w'
-  }
-
-  div.style.cursor = `${cursorDirection}-resize`
-
-  return div
-}
+	return div;
+};
 
 function getTransform(element: HTMLElement) {
-  const style = getComputedStyle(element)
-  const matrix = style.transform
+	const style = getComputedStyle(element);
+	const matrix = style.transform;
 
-  const matrixType = matrix.includes('3d') ? '3d' : '2d'
-  const matrixValues = matrix.match(/matrix.*\((.+)\)/)?.[1].split(", ").map((strNum) => parseInt(strNum))
+	const matrixType = matrix.includes('3d') ? '3d' : '2d';
+	const matrixValues = matrix
+		.match(/matrix.*\((.+)\)/)?.[1]
+		.split(', ')
+		.map((strNum) => parseInt(strNum));
 
+	if (matrixType === '2d') {
+		return {
+			x: matrixValues?.[4] ?? 0,
+			y: matrixValues?.[5] ?? 0,
+			z: 0
+		};
+	}
 
-  if (matrixType === '2d') {
-    return {
-      x: matrixValues?.[4] ?? 0,
-      y: matrixValues?.[5] ?? 0,
-      z: 0
-    }
-  }
+	if (matrixType === '3d') {
+		return {
+			x: matrixValues?.[12] ?? 0,
+			y: matrixValues?.[13] ?? 0,
+			z: matrixValues?.[14] ?? 0
+		};
+	}
 
-  if (matrixType === '3d') {
-    return {
-      x: matrixValues?.[12] ?? 0,
-      y: matrixValues?.[13] ?? 0,
-      z: matrixValues?.[14] ?? 0
-    }
-  }
-
-  return {
-    x: 0,
-    y: 0,
-    z: 0
-  }
+	return {
+		x: 0,
+		y: 0,
+		z: 0
+	};
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,8 +5,8 @@
 <table>
 	<thead>
 		<tr>
-			<th use:resize> Column 1</th>
-			<th use:resize> Column 2</th>
+			<th use:resize={{ handlers: { right: true } }}> Column 1</th>
+			<th use:resize={{ handlers: { right: true } }}> Column 2</th>
 		</tr>
 	</thead>
 	<tbody>
@@ -28,9 +28,19 @@
 		height: 500px;
 		background: grey;
 	}
+	.box:nth-child(1) {
+		background: aqua;
+	}
+
 	.flex {
+		margin: 1rem;
 		display: flex;
 	}
+
+	table {
+		margin: 1rem;
+	}
+
 	th {
 		position: relative;
 	}


### PR DESCRIPTION
With the following command, only right handlers are visible. Unfortunately the handlers are not positioned properly. Ideally the handlers are vertically centered.

`<th use:resize={{ handlers: { right: true } }}> Column 1</th>`